### PR TITLE
Always install when running "make install"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,8 +54,6 @@ if(${NUPIC_IWYU})
   endif()
 endif()
 
-option(NUPIC_TOGGLE_INSTALL "Toggle whether to install headers, libraries, and executables to the install location for C++ clients" OFF)
-
 #
 # Set up compile flags for internal sources
 #
@@ -587,54 +585,47 @@ install(TARGETS
 install(FILES ${PROJECT_BINARY_DIR}/Version.hpp
         DESTINATION include/nupic)
 
-if (NUPIC_TOGGLE_INSTALL)
-  install(DIRECTORY nupic DESTINATION include
-          MESSAGE_NEVER
-          FILES_MATCHING PATTERN "*.h*"
-          PATTERN "*.hpp.in" EXCLUDE)
-  install(DIRECTORY nupic DESTINATION include
-          MESSAGE_NEVER
-          FILES_MATCHING PATTERN "*.i")
-  install(DIRECTORY nupic DESTINATION include
-          MESSAGE_NEVER
-          FILES_MATCHING PATTERN "*.capnp")
-  install(DIRECTORY ${PROJECT_BINARY_DIR}/nupic DESTINATION include
-          MESSAGE_NEVER
-          FILES_MATCHING PATTERN "*.capnp.h")
+install(DIRECTORY nupic DESTINATION include
+        MESSAGE_NEVER
+        FILES_MATCHING PATTERN "*.h*"
+        PATTERN "*.hpp.in" EXCLUDE)
+install(DIRECTORY nupic DESTINATION include
+        MESSAGE_NEVER
+        FILES_MATCHING PATTERN "*.i")
+install(DIRECTORY nupic DESTINATION include
+        MESSAGE_NEVER
+        FILES_MATCHING PATTERN "*.capnp")
+install(DIRECTORY ${PROJECT_BINARY_DIR}/nupic DESTINATION include
+        MESSAGE_NEVER
+        FILES_MATCHING PATTERN "*.capnp.h")
 
-  install(DIRECTORY ${REPOSITORY_DIR}/external/common/include/gtest
-          MESSAGE_NEVER
-          DESTINATION include/gtest
-          FILES_MATCHING PATTERN "*.h*")
+install(DIRECTORY ${REPOSITORY_DIR}/external/common/include/gtest
+        MESSAGE_NEVER
+        DESTINATION include/gtest
+        FILES_MATCHING PATTERN "*.h*")
 
-  install(DIRECTORY "${REPOSITORY_DIR}/external/common/include/"
+install(DIRECTORY "${REPOSITORY_DIR}/external/common/include/"
+        MESSAGE_NEVER
+        DESTINATION include)
+
+install(DIRECTORY nupic DESTINATION include/nupic
+        MESSAGE_NEVER
+        FILES_MATCHING PATTERN "*.py")
+
+foreach(directory ${CAPNP_INCLUDE_DIRS})
+  install(DIRECTORY "${directory}/capnp"
           MESSAGE_NEVER
           DESTINATION include)
-
-  install(DIRECTORY nupic DESTINATION include/nupic
+  install(DIRECTORY "${directory}/kj"
           MESSAGE_NEVER
-          FILES_MATCHING PATTERN "*.py")
+          DESTINATION include)
+endforeach()
 
-  foreach(directory ${CAPNP_INCLUDE_DIRS})
-    install(DIRECTORY "${directory}/capnp"
-            MESSAGE_NEVER
-            DESTINATION include)
-    install(DIRECTORY "${directory}/kj"
-            MESSAGE_NEVER
-            DESTINATION include)
-  endforeach()
-
-  install(DIRECTORY "${CAPNP_BINARIES}"
-          MESSAGE_NEVER
-          DESTINATION "${CMAKE_INSTALL_PREFIX}"
-          USE_SOURCE_PERMISSIONS
-          FILES_MATCHING PATTERN "capnp*")
-
-  install(DIRECTORY "${SWIG_DIR}"
-          MESSAGE_NEVER
-          DESTINATION share/swig)
-  install(PROGRAMS "${SWIG_EXECUTABLE}"
-          DESTINATION bin)
+install(DIRECTORY "${CAPNP_BINARIES}"
+        MESSAGE_NEVER
+        DESTINATION "${CMAKE_INSTALL_PREFIX}"
+        USE_SOURCE_PERMISSIONS
+        FILES_MATCHING PATTERN "capnp*")
 
   # install(DIRECTORY "${APR1_STATIC_LIB_INC_DIR}/"
   #         MESSAGE_NEVER
@@ -642,8 +633,6 @@ if (NUPIC_TOGGLE_INSTALL)
   # install(DIRECTORY "${APRUTIL1_STATIC_LIB_INC_DIR}/"
   #         MESSAGE_NEVER
   #         DESTINATION include)
-
-endif (NUPIC_TOGGLE_INSTALL)
 
 #
 # `make package` results in


### PR DESCRIPTION
It was enabled by default previously, but stopped being enabled when I removed the PYEXT logic.