### PR TITLE
Support SparseMatrix(npArray.transpose())

### DIFF
--- a/bindings/py/nupic/bindings/math/sparse_binary_matrix.py
+++ b/bindings/py/nupic/bindings/math/sparse_binary_matrix.py
@@ -32,7 +32,7 @@ class SparseBinaryMatrix(_nupic.SparseBinaryMatrix):
                 self.fromCSR(args[0])
             elif isinstance(args[0], np.ndarray) or hasattr(args[0], '__iter__'):
                 super().__init__(1)
-                self.fromDense(np.asarray(args[0]))
+                self.fromDense(np.ascontiguousarray(args[0]))
             elif isinstance(args[0], int):
                 super().__init__(args[0])
             elif isinstance(args[0], _SM_01_32_32):
@@ -59,7 +59,7 @@ class SparseBinaryMatrix(_nupic.SparseBinaryMatrix):
         self.set(index[0], index[1], value)
 
     def fromDense(self, m):
-        m = np.asarray(m, dtype="bool")
+        m = np.ascontiguousarray(m, dtype="bool")
         self._fromDense(m.shape[0], m.shape[1], m)
 
     def rightVecSumAtNZ(self, denseArray, out=None):

--- a/bindings/py/nupic/bindings/math/sparse_matrix.py
+++ b/bindings/py/nupic/bindings/math/sparse_matrix.py
@@ -72,7 +72,7 @@ class SparseMatrix(_nupic.SparseMatrix):
             self.fromPyString(serialized)
 
         elif dense is not None:
-            self.fromDense(np.asarray(dense, dtype=np.float32))
+            self.fromDense(np.ascontiguousarray(dense, dtype=np.float32))
 
         elif from01:
             nz_i,nz_j = args[0].getAllNonZeros(True)
@@ -252,7 +252,7 @@ class SparseMatrix(_nupic.SparseMatrix):
         return result
 
     def fromDense(self, m):
-        m = np.asarray(m, dtype="float32")
+        m = np.ascontiguousarray(m, dtype="float32")
         self._fromDense(m.shape[0], m.shape[1], m)
 
     def rightVecSumAtNZ(self, denseArray, out=None):

--- a/bindings/py/tests/sparse_matrix_test.py
+++ b/bindings/py/tests/sparse_matrix_test.py
@@ -3742,6 +3742,28 @@ class SparseMatrixTest(unittest.TestCase):
               total_calls = total_calls + ncalls
           print(avg_T, total_calls, avg_T / float(total_calls))
 
+  def test_construct_from_numpy(self):
+
+    print('Testing construct_from_numpy')
+
+    arr1 = numpy.array([[0, 1, 2],
+                        [3, 4, 5]], 
+                        dtype=numpy.float32)
+    # Also test a transposed version of the same matrix.
+    arr2 = numpy.array([[0, 3],
+                        [1, 4],
+                        [2, 5]], 
+                        dtype=numpy.float32)
+    sm1 = SM32(arr1)
+    sm2 = SM32(arr2.transpose())
+
+    out1 = sm1.toDense()
+    out2 = sm2.toDense()
+
+    numpy.testing.assert_equal(out1, arr1)
+    numpy.testing.assert_equal(out2, arr1)
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before this change, the SparseMatrix quietly did the wrong thing when fed a non-contiguous numpy array